### PR TITLE
Add support for extra CLI arguments

### DIFF
--- a/charts/kubernetes-dashboard-proxy/Chart.yaml
+++ b/charts/kubernetes-dashboard-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: A reverse proxy with OpenID Connect for Kubernetes Dashboard
 name: kubernetes-dashboard-proxy
-version: 1.4.1
+version: 1.5.0
 appVersion: 2.3.0

--- a/charts/kubernetes-dashboard-proxy/templates/deployment.yaml
+++ b/charts/kubernetes-dashboard-proxy/templates/deployment.yaml
@@ -55,6 +55,9 @@ spec:
           {{- if .Values.proxy.oidc.scopes }}
             - "--scopes={{ .Values.proxy.oidc.scopes }}"
           {{- end }}
+          {{- with .Values.proxy.extraArgs }}
+{{ toYaml . | indent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 3000

--- a/charts/kubernetes-dashboard-proxy/values.yaml
+++ b/charts/kubernetes-dashboard-proxy/values.yaml
@@ -24,6 +24,10 @@ proxy:
   enableAuthorizationHeader: true
   ## Add the authorization cookies to the uptream proxy request.
   enableAuthorizationCookies: false
+  ## Extra argumets for keycloak-proxy
+  extraArgs: []
+  #  - --skip-openid-provider-tls-verify
+  #  - --scopes=groups
 
 replicaCount: 1
 


### PR DESCRIPTION
The newly added `extraArgs` parameter allows to add any other arguments to `keycloak-proxy` container command.